### PR TITLE
Create gempush.yml

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -1,0 +1,19 @@
+- name: Setup Java JDK
+  uses: actions/setup-java@v1.3.0
+  with:
+    # The Java version to make available on the path. Takes a whole or semver Java version, or 1.x syntax (e.g. 1.8 => Java 8.x)
+    java-version: 
+    # The package type (jre, jdk, jdk+fx)
+    java-package: # optional, default is jdk
+    # The architecture (x86, x64) of the package.
+    architecture: # optional, default is x64
+    # Path to where the compressed JDK is located. The path could be in your source repository or a local path on the agent.
+    jdkFile: # optional
+    # ID of the distributionManagement repository in the pom.xml file. Default is `github`
+    server-id: # optional
+    # Environment variable name for the username for authentication to the Apache Maven repository. Default is $GITHUB_ACTOR
+    server-username: # optional
+    # Environment variable name for password or token for authentication to the Apache Maven repository. Default is $GITHUB_TOKEN
+    server-password: # optional
+    # Path to where the settings.xml file will be written. Default is ~/.m2.
+    settings-path: # optional


### PR DESCRIPTION
- name: Setup Java JDK
  uses: actions/setup-java@v1.3.0
  with:
    # The Java version to make available on the path. Takes a whole or semver Java version, or 1.x syntax (e.g. 1.8 => Java 8.x)
    java-version: 
    # The package type (jre, jdk, jdk+fx)
    java-package: # optional, default is jdk
    # The architecture (x86, x64) of the package.
    architecture: # optional, default is x64
    # Path to where the compressed JDK is located. The path could be in your source repository or a local path on the agent.
    jdkFile: # optional
    # ID of the distributionManagement repository in the pom.xml file. Default is `github`
    server-id: # optional
    # Environment variable name for the username for authentication to the Apache Maven repository. Default is $GITHUB_ACTOR
    server-username: # optional
    # Environment variable name for password or token for authentication to the Apache Maven repository. Default is $GITHUB_TOKEN
    server-password: # optional
    # Path to where the settings.xml file will be written. Default is ~/.m2.
    settings-path: # optional